### PR TITLE
Grants Roboticists the ability to speak synthetic languages

### DIFF
--- a/code/modules/jobs/job_types/science.dm
+++ b/code/modules/jobs/job_types/science.dm
@@ -129,3 +129,13 @@ Roboticist
 	satchel = /obj/item/storage/backpack/satchel/tox
 
 	pda_slot = slot_l_store
+	
+/datum/job/roboticist/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+	..()
+
+	if(visualsOnly)
+		return
+
+	H.grant_language(/datum/language/drone)
+	H.grant_language(/datum/language/machine)
+	H.grant_language(/datum/language/swarmer)


### PR DESCRIPTION

[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. This includes, new features, sprites, sounds, balance changes, admin tools, map edits, removals, big refactors, config changes, hosting changes and important fixes. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs)

:cl: cacogen
add: As part of their training, Roboticists now know synthetic languages
/:cl:

[why]: # (Please add a short description [two lines down] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.)

I was in robotics when swarmers attacked and destroyed one of their durands. It struck me as ironic and then I wondered why Roboticists of all jobs don't have some role-specific ability for dealing with malfunctioning robots.

also westworld is a cool show
