### PR TITLE
Makes long numbered station name rarer

### DIFF
--- a/code/__HELPERS/names.dm
+++ b/code/__HELPERS/names.dm
@@ -66,7 +66,7 @@ GLOBAL_VAR(command_name)
 		new_station_name = name + " "
 		name = ""
 
-	if(prob(1))
+	if(prob(0.1))
 		random = 999999999 //ridiculously long name in written numbers
 
 	// Prefix
@@ -101,7 +101,7 @@ GLOBAL_VAR(command_name)
 		if(13)
 			new_station_name += pick("13","XIII","Thirteen")
 		if(999999999)
-			new_station_name = "Space Station " + convert_integer_to_words(rand(111111111,999999999), capitalise = TRUE)
+			new_station_name += convert_integer_to_words(rand(111111111,999999999), capitalise = TRUE)
 	return new_station_name
 
 /proc/syndicate_name()


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Also makes it use normal prefixes rather than the generic "Space Station", which saps all the joy out of life

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

This is supposed to appear in only 1% of rounds but I see it way too often and it quickly wears out its welcome
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: The generic station name with the big number will appear less often now
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
